### PR TITLE
fix #91

### DIFF
--- a/src/main/java/leppa/planarartifice/registry/PAAspects.java
+++ b/src/main/java/leppa/planarartifice/registry/PAAspects.java
@@ -270,7 +270,7 @@ public class PAAspects {
 		// only EntityLiving can be sacrificed
 		remove("chicken", new Aspects("volatus", 999));
 		add("creeper", new Aspects("exitium", 10));
-		set("ender_dragon", get("enderman").multiply(2).add("draco", 50));
+
 		add("llama", new Aspects("spatio", 5));
 		add("polar_bear", new Aspects("victus", 10));
 		set("rabbit", new Aspects("motus", 5, "bestia", 5, "tempus", 5));
@@ -287,11 +287,20 @@ public class PAAspects {
 		set("donkey", new Aspects("herba", 15, "terra", 5, "bestia", 15));
 		set("mule", new Aspects("spatio", 15, "terra", 5, "bestia", 15));
 		set("horse", new Aspects("motus", 15, "terra", 5, "bestia", 15));
-		// infernum for the netherdwellers
-		add("blaze", new Aspects("infernum", 5));
-		add("ghast", new Aspects("spiritus", 10, "infernum", 5));
-		add("magma_cube", new Aspects("infernum", 5, "alienis", 10));
-		add("zombie_pigman", new Aspects("infernum", 5));
+		
+		// thaumadd aspects
+		if(Loader.isModLoaded("thaumadditions")){
+			set("ender_dragon", get("enderman").multiply(2).add("draco", 50));
+			set("thaumcraft:golem", getRaw("Thaumcraft.Golem").add("imperium", 10));
+			// infernum for the netherdwellers
+			add("blaze", new Aspects("infernum", 5));
+			add("ghast", new Aspects("spiritus", 10, "infernum", 5));
+			add("magma_cube", new Aspects("infernum", 5, "alienis", 10));
+			add("zombie_pigman", new Aspects("infernum", 5));
+			set("thaumcraft:firebat", getRaw("Thaumcraft.Firebat").add("infernum", 10));
+
+			set("dragon_fireball", get(Items.FIRE_CHARGE).add("draco", 25).add("tenebrae", 10));
+		}
 		// you're literally thaumcraft??? why don't you have aspects???
 		set("thaumcraft:brainyzombie", getRaw("Thaumcraft.BrainyZombie"));
 		set("thaumcraft:giantbrainyzombie", getRaw("Thaumcraft.GiantBrainyZombie"));
@@ -304,7 +313,7 @@ public class PAAspects {
 		set("thaumcraft:eldritchgolem", new Aspects("praemunio", 25, "alienis", 25, "vitium", 25, "machina", 25, "praecantatio", 25));
 		set("thaumcraft:eldritchguardian", new Aspects("spiritus", 25, "alienis", 25, "vitium", 25, "cognitio", 25, "praecantatio", 25));
 		set("thaumcraft:eldritchwarden", new Aspects("tenebrae", 25, "alienis", 25, "vitium", 25, "exanimis", 25, "praecantatio", 25));
-		set("thaumcraft:firebat", getRaw("Thaumcraft.Firebat").add("infernum", 10));
+		
 		// flux rift is made of pure impetus, no essentia is registered
 		set("thaumcraft:inhabitedzombie", get("zombie").add("vitium", 15).add("alienis", 10).add("praecantatio", 10).add("praemunio", 10));
 		set("thaumcraft:mindspider", get("spider").add("spiritus", 5).add("cognitio", 10).add("praecantatio", 5).add("alienis", 5));
@@ -319,7 +328,6 @@ public class PAAspects {
 		set("thaumcraft:taintseedprime", get("thaumcraft:taintseed").multiply(2F));
 		set("thaumcraft:thaumslime", getRaw("Thaumcraft.ThaumSlime"));
 		set("thaumcraft:taintswarm", getRaw("Thaumcraft.TaintSwarm"));
-		set("thaumcraft:golem", getRaw("Thaumcraft.Golem").add("imperium", 10));
 		for (Aspect aspect : Aspect.aspects.values())
 			set("thaumcraft:wisp", new Aspects("sol", 5, "auram", 5, "volatus", 5).add(aspect, 2), new ThaumcraftApi.EntityTagsNBT("Type", aspect.getTag()));
 		// ITEM->ENTITY
@@ -350,7 +358,6 @@ public class PAAspects {
 		// add("lightning_bolt", new Aspects("potentia", 25, "lux", 10).add("exitium", 10, "perditio"));
 		set("fireball", get(Items.FIRE_CHARGE));
 		set("small_fireball", get(Items.FIRE_CHARGE).multiply(0.5F));
-		set("dragon_fireball", get(Items.FIRE_CHARGE).add("draco", 25).add("tenebrae", 10));
 		set("egg", get(Items.EGG));
 		set("snowball", get(Items.SNOWBALL));
 		set("ender_pearl", get(Items.ENDER_PEARL));


### PR DESCRIPTION
This simple fix should stop the thaumometer crashes reported in #91 and confirmed by me. The cause of the crash is thaumcraft attempting to render aspects that do not exist when the Thaumic Additions mod is not present; Planar Artifice attempts to add aspects from Thaumic Additions to several entities (golems, firebats, many nether mobs, and the ender dragon) without checking if it is loaded; thus, when the thaumometer attempts to render the aspect display for that entity, Thaumcraft's drawTagsOnContainer crashes as it is unable to find the icons for those non-existing aspects.

In addition, there appears to be a similar issue in the same file with several items (in and near the ingot handler), however I am not familiar with the source mods, so that fix will need to be implemented by someone else. It is possible that thaumcraft handles item aspect display failure more gracefully than entity aspect display failure, but this should not be relied upon. I recommend implementing checks for whether a mod is loaded in all such cases, since no mod other than Thaumcraft is marked as a hard dependency.

The build configuration in this project is broken, and as such I am unable to test the fix. Recommend testing before publish.